### PR TITLE
Feature screenobject rubbish

### DIFF
--- a/pa-2d-game/src/entities/Rubbish.tsx
+++ b/pa-2d-game/src/entities/Rubbish.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Collider, { TriggerEvent } from '../@core/Collider';
+import GameObject, { GameObjectProps } from '../@core/GameObject';
+import Sprite from '../@core/Sprite';
+import useGameObjectEvent from '../@core/useGameObjectEvent';
+import spriteData from '../spriteData';
+
+function TriggerScript() {
+    useGameObjectEvent<TriggerEvent>('trigger', other => {
+        if (other.name === 'player') {
+            // TODO: signal score loss
+            // eslint-disable-next-line no-console
+            // console.log('rubish collision');
+        }
+    });
+
+    return null;
+}
+
+export default function Rubbish(props: GameObjectProps) {
+    const name = `rubbish-${props.x}-${props.y}`; // fallback name required for persisted flag
+    return (
+        <GameObject name={name} persisted {...props}>
+            <Sprite {...spriteData.objects} state="plant" />
+            <Collider isTrigger />
+            <TriggerScript />
+        </GameObject>
+    );
+}


### PR DESCRIPTION
Använder plant-spriten för att visa ett objekt som representerar bråte (Rubbish). 

* Blockerar inte spelaren men utlöser en ett kollisions-script.